### PR TITLE
Add enable toggle for render queue jobs

### DIFF
--- a/rqm/operators_queue.py
+++ b/rqm/operators_queue.py
@@ -1,31 +1,44 @@
 """Queue management operators."""
+
 from __future__ import annotations
+
 import os
+
 import bpy  # type: ignore
+from bpy.props import EnumProperty, IntProperty  # type: ignore
 from bpy.types import Operator  # type: ignore
-from bpy.props import IntProperty, EnumProperty  # type: ignore
-from .state import get_state
-from .properties import RQM_Job
+
 from .handlers import register_handlers
-from .utils import _sanitize_component
 from .jobs import apply_job
+from .properties import RQM_Job
+from .state import get_state
+from .utils import _sanitize_component
+
 
 # ---- Local item callbacks (avoid lambda for Blender EnumProperty) ----
 def _operator_scene_items(self, context):
     items = [(s.name, s.name, '') for s in bpy.data.scenes]
-    return items or [('','<no scenes>','')]
+    return items or [('', '<no scenes>', '')]
+
 
 __all__ = [
-    'RQM_OT_AddFromCurrent','RQM_OT_AddCamerasInScene','RQM_OT_RemoveJob','RQM_OT_ClearQueue',
-    'RQM_OT_MoveJob','RQM_OT_StartQueue','RQM_OT_StopQueue',
-    'RQM_OT_DuplicateJob'
+    'RQM_OT_AddFromCurrent',
+    'RQM_OT_AddCamerasInScene',
+    'RQM_OT_RemoveJob',
+    'RQM_OT_ClearQueue',
+    'RQM_OT_MoveJob',
+    'RQM_OT_StartQueue',
+    'RQM_OT_StopQueue',
+    'RQM_OT_DuplicateJob',
 ]
+
 
 class RQM_OT_AddFromCurrent(Operator):
     bl_idname = 'rqm.add_from_current'
     bl_label = 'Add Job (Use current scene & camera)'
     bl_description = 'Add a job using the current scene, camera, and render settings'
-    bl_options = {'REGISTER','UNDO'}
+    bl_options = {'REGISTER', 'UNDO'}
+
     def execute(self, context):
         st = get_state(context)
         if st is None:
@@ -45,7 +58,11 @@ class RQM_OT_AddFromCurrent(Operator):
         job.zero_index_numbering = True
         job.file_format = 'PNG'
         existing = scn.render.filepath or '//renders/'
-        if existing and not existing.endswith(('/', '\\')) and not os.path.isdir(bpy.path.abspath(existing)):
+        if (
+            existing
+            and not existing.endswith(('/', '\\'))
+            and not os.path.isdir(bpy.path.abspath(existing))
+        ):
             existing = os.path.dirname(existing) + os.sep
         job.output_path = existing or '//renders/'
         job.file_basename = 'render'
@@ -59,20 +76,23 @@ class RQM_OT_AddFromCurrent(Operator):
             job.stereo_views_format = 'STEREO_3D'
         cam_part = job.camera_name or 'noCam'
         job.name = f'{job.scene_name}_{cam_part}'
-        st.active_index = len(st.queue)-1
+        st.active_index = len(st.queue) - 1
         self.report({'INFO'}, 'Job added.')
         return {'FINISHED'}
+
 
 class RQM_OT_AddCamerasInScene(Operator):
     bl_idname = 'rqm.add_cameras_in_scene'
     bl_label = 'Add Jobs for all cameras in a scene'
     bl_description = 'Create one job per camera in the chosen scene'
-    bl_options = {'REGISTER','UNDO'}
+    bl_options = {'REGISTER', 'UNDO'}
     scene_name: EnumProperty(name='Scene', items=_operator_scene_items)
+
     def invoke(self, context, event):
         if not self.scene_name and context.scene:
             self.scene_name = context.scene.name
         return context.window_manager.invoke_props_dialog(self)
+
     def execute(self, context):
         st = get_state(context)
         if st is None:
@@ -100,7 +120,11 @@ class RQM_OT_AddCamerasInScene(Operator):
             job.zero_index_numbering = True
             job.file_format = 'PNG'
             existing = scn.render.filepath or '//renders/'
-            if existing and not existing.endswith(('/', '\\')) and not os.path.isdir(bpy.path.abspath(existing)):
+            if (
+                existing
+                and not existing.endswith(('/', '\\'))
+                and not os.path.isdir(bpy.path.abspath(existing))
+            ):
                 existing = os.path.dirname(existing) + os.sep
             job.output_path = existing or '//renders/'
             job.file_basename = cam.name
@@ -109,16 +133,18 @@ class RQM_OT_AddCamerasInScene(Operator):
                 job.use_stereoscopy = False
             if hasattr(job, 'stereo_views_format'):
                 job.stereo_views_format = 'STEREO_3D'
-        st.active_index = len(st.queue)-1
+        st.active_index = len(st.queue) - 1
         self.report({'INFO'}, f'Added {len(cams)} jobs.')
         return {'FINISHED'}
+
 
 class RQM_OT_RemoveJob(Operator):
     bl_idname = 'rqm.remove_job'
     bl_label = 'Remove Job'
     bl_description = 'Remove the selected job from the queue'
-    bl_options = {'REGISTER','UNDO'}
+    bl_options = {'REGISTER', 'UNDO'}
     index: IntProperty(default=-1)
+
     def execute(self, context):
         st = get_state(context)
         if st is None:
@@ -126,30 +152,35 @@ class RQM_OT_RemoveJob(Operator):
         idx = self.index if self.index >= 0 else st.active_index
         if 0 <= idx < len(st.queue):
             st.queue.remove(idx)
-            st.active_index = min(idx, len(st.queue)-1)
+            st.active_index = min(idx, len(st.queue) - 1)
             self.report({'INFO'}, 'Job removed.')
             return {'FINISHED'}
         return {'CANCELLED'}
+
 
 class RQM_OT_ClearQueue(Operator):
     bl_idname = 'rqm.clear_queue'
     bl_label = 'Clear All Jobs'
     bl_description = 'Remove all jobs from the queue'
-    bl_options = {'REGISTER','UNDO'}
+    bl_options = {'REGISTER', 'UNDO'}
+
     def execute(self, context):
         st = get_state(context)
         if st is None:
             return {'CANCELLED'}
-        st.queue.clear(); st.active_index = 0
+        st.queue.clear()
+        st.active_index = 0
         self.report({'INFO'}, 'Queue cleared.')
         return {'FINISHED'}
+
 
 class RQM_OT_DuplicateJob(Operator):
     bl_idname = 'rqm.duplicate_job'
     bl_label = 'Duplicate Job'
     bl_description = 'Duplicate the selected job and its settings'
-    bl_options = {'REGISTER','UNDO'}
+    bl_options = {'REGISTER', 'UNDO'}
     index: IntProperty(default=-1)
+
     def execute(self, context):
         st = get_state(context)
         if st is None or not st.queue:
@@ -161,11 +192,34 @@ class RQM_OT_DuplicateJob(Operator):
         dst = st.queue.add()
         # Copy simple attributes
         for attr in [
-            'scene_name','camera_name','engine','res_x','res_y','percent',
-            'use_animation','frame_start','frame_end','link_timeline_markers','link_marker','marker_name','marker_offset',
-            'link_end_marker','end_marker_name','end_marker_offset','file_format','output_path','file_basename','rebase_numbering',
-            'use_comp_outputs','comp_outputs_non_blocking','use_stereoscopy','stereo_views_format','stereo_extra_tags',
-            'stereo_keep_plain','use_tag_collection'
+            'enabled',
+            'scene_name',
+            'camera_name',
+            'engine',
+            'res_x',
+            'res_y',
+            'percent',
+            'use_animation',
+            'frame_start',
+            'frame_end',
+            'link_timeline_markers',
+            'link_marker',
+            'marker_name',
+            'marker_offset',
+            'link_end_marker',
+            'end_marker_name',
+            'end_marker_offset',
+            'file_format',
+            'output_path',
+            'file_basename',
+            'rebase_numbering',
+            'use_comp_outputs',
+            'comp_outputs_non_blocking',
+            'use_stereoscopy',
+            'stereo_views_format',
+            'stereo_extra_tags',
+            'stereo_keep_plain',
+            'use_tag_collection',
         ]:
             if hasattr(dst, attr) and hasattr(src, attr):
                 setattr(dst, attr, getattr(src, attr))
@@ -173,58 +227,75 @@ class RQM_OT_DuplicateJob(Operator):
         if hasattr(src, 'comp_outputs'):
             for out in src.comp_outputs:
                 new_out = dst.comp_outputs.add()
-                for a in ['enabled','node_name','create_if_missing','base_source','base_file','use_node_named_subfolder','extra_subfolder','ensure_dirs','override_node_format']:
+                for a in [
+                    'enabled',
+                    'node_name',
+                    'create_if_missing',
+                    'base_source',
+                    'base_file',
+                    'use_node_named_subfolder',
+                    'extra_subfolder',
+                    'ensure_dirs',
+                    'override_node_format',
+                ]:
                     if hasattr(out, a):
                         setattr(new_out, a, getattr(out, a))
         # Copy tag collection
         if hasattr(src, 'stereo_tags'):
             for t in src.stereo_tags:
                 nt = dst.stereo_tags.add()
-                nt.name = t.name; nt.enabled = t.enabled
+                nt.name = t.name
+                nt.enabled = t.enabled
         dst.name = src.name + '_dup'
-        st.active_index = len(st.queue)-1
+        st.active_index = len(st.queue) - 1
         self.report({'INFO'}, 'Job duplicated.')
         return {'FINISHED'}
 
-        
 
 class RQM_OT_MoveJob(Operator):
     bl_idname = 'rqm.move_job'
     bl_label = 'Move Job'
     bl_description = 'Move the selected job up or down in the queue'
-    bl_options = {'REGISTER','UNDO'}
-    direction: EnumProperty(items=[('UP','Up',''),('DOWN','Down','')])
+    bl_options = {'REGISTER', 'UNDO'}
+    direction: EnumProperty(items=[('UP', 'Up', ''), ('DOWN', 'Down', '')])
+
     def execute(self, context):
         st = get_state(context)
         if st is None:
             return {'CANCELLED'}
         idx = st.active_index
         if self.direction == 'UP' and idx > 0:
-            st.queue.move(idx, idx-1)
+            st.queue.move(idx, idx - 1)
             st.active_index -= 1
             return {'FINISHED'}
-        if self.direction == 'DOWN' and idx < len(st.queue)-1:
-            st.queue.move(idx, idx+1)
+        if self.direction == 'DOWN' and idx < len(st.queue) - 1:
+            st.queue.move(idx, idx + 1)
             st.active_index += 1
             return {'FINISHED'}
         return {'CANCELLED'}
 
- # apply_job now imported from jobs module
+
+# apply_job now imported from jobs module
+
 
 class RQM_OT_StartQueue(Operator):
     bl_idname = 'rqm.start_queue'
     bl_label = 'Start Render Queue'
     bl_description = 'Start rendering all jobs in the queue in order'
     bl_options = {'REGISTER'}
+
     def execute(self, context):
         st = get_state(context)
         if st is None or st.running or not st.queue:
             return {'CANCELLED'}
         register_handlers()
-        st.running = True; st.current_job_index = 0; st.render_in_progress = False
+        st.running = True
+        st.current_job_index = 0
+        st.render_in_progress = False
         context.window_manager.modal_handler_add(self)
         self.report({'INFO'}, 'Render queue started.')
         return {'RUNNING_MODAL'}
+
     def modal(self, context, event):
         st = get_state(context)
         if st is None or not st.running:
@@ -234,7 +305,9 @@ class RQM_OT_StartQueue(Operator):
             register_handlers()
         except Exception:
             pass
-    # Process jobs sequentially
+        # Process jobs sequentially
+        while st.current_job_index < len(st.queue) and not st.queue[st.current_job_index].enabled:
+            st.current_job_index += 1
         if st.current_job_index >= len(st.queue):
             st.running = False
             st.current_job_index = -1
@@ -262,27 +335,34 @@ class RQM_OT_StartQueue(Operator):
             return {'PASS_THROUGH'}
         st.render_in_progress = True
         try:
-            # Use EXEC_DEFAULT to avoid needing the Image Editor foreground; more reliable unattended.
+            # Use EXEC_DEFAULT to avoid needing the Image Editor
+            # foreground; more reliable unattended.
             if job.use_animation:
                 bpy.ops.render.render('EXEC_DEFAULT', animation=True)
             else:
                 bpy.ops.render.render('EXEC_DEFAULT', write_still=True)
-            print(f"[RQM] Started render for job {st.current_job_index+1}/{len(st.queue)}: {job.name}")
+            print(
+                f"[RQM] Started render for job {st.current_job_index+1}/{len(st.queue)}: {job.name}"
+            )
         except Exception as e:
             self.report({'ERROR'}, str(e))
             st.render_in_progress = False
             st.current_job_index += 1
         return {'PASS_THROUGH'}
 
+
 class RQM_OT_StopQueue(Operator):
     bl_idname = 'rqm.stop_queue'
     bl_label = 'Stop Render Queue'
     bl_description = 'Stop the render queue and reset state'
     bl_options = {'REGISTER'}
+
     def execute(self, context):
         st = get_state(context)
         if st is None:
             return {'CANCELLED'}
-        st.running = False; st.current_job_index = -1; st.render_in_progress = False
+        st.running = False
+        st.current_job_index = -1
+        st.render_in_progress = False
         self.report({'INFO'}, 'Queue stopped.')
         return {'FINISHED'}

--- a/rqm/properties.py
+++ b/rqm/properties.py
@@ -1,40 +1,70 @@
 """Property groups and shared data structures."""
+
 from __future__ import annotations
+
 import os
+
 import bpy  # type: ignore  # Blender runtime provided
 from bpy.props import (  # type: ignore
-    StringProperty, BoolProperty, IntProperty, EnumProperty,
-    PointerProperty, CollectionProperty
+    BoolProperty,
+    CollectionProperty,
+    EnumProperty,
+    IntProperty,
+    PointerProperty,
+    StringProperty,
 )
 from bpy.types import PropertyGroup  # type: ignore
-from .utils import scene_items, camera_items, engine_items, FILE_FORMAT_ITEMS, _sanitize_component
 
-__all__ = ['RQM_CompOutput','RQM_Job','RQM_State','RQM_Tag']
+from .utils import FILE_FORMAT_ITEMS, _sanitize_component, camera_items, engine_items, scene_items
+
+__all__ = ['RQM_CompOutput', 'RQM_Job', 'RQM_State', 'RQM_Tag']
+
 
 class RQM_Tag(PropertyGroup):
     name: StringProperty(name='Tag')
     enabled: BoolProperty(name='Use', default=True)
 
+
 class RQM_CompOutput(PropertyGroup):
-    enabled: BoolProperty(name='Enabled', default=True,
-        description='Include this File Output node when rendering this job')
-    node_name: StringProperty(name='File Output Node', default='',
-        description="Pick a Compositor File Output node to drive. We'll set its base folder only.")
-    create_if_missing: BoolProperty(name='Create if missing (once)', default=False,
-        description="If the node isn't found, create and remember one")
-    base_source: EnumProperty(name='Base folder', items=[
-        ('JOB_OUTPUT','Job output folder','Use the job\'s Render folder'),
-        ('SCENE_OUTPUT','Scene output folder','Use Output Properties → Output directory'),
-        ('FROM_FILE','Folder of a chosen file','Pick any file; we use its folder'),
-    ], default='JOB_OUTPUT')
+    enabled: BoolProperty(
+        name='Enabled',
+        default=True,
+        description='Include this File Output node when rendering this job',
+    )
+    node_name: StringProperty(
+        name='File Output Node',
+        default='',
+        description="Pick a Compositor File Output node to drive. We'll set its base folder only.",
+    )
+    create_if_missing: BoolProperty(
+        name='Create if missing (once)',
+        default=False,
+        description="If the node isn't found, create and remember one",
+    )
+    base_source: EnumProperty(
+        name='Base folder',
+        items=[
+            ('JOB_OUTPUT', 'Job output folder', 'Use the job\'s Render folder'),
+            ('SCENE_OUTPUT', 'Scene output folder', 'Use Output Properties → Output directory'),
+            ('FROM_FILE', 'Folder of a chosen file', 'Pick any file; we use its folder'),
+        ],
+        default='JOB_OUTPUT',
+    )
     base_file: StringProperty(name='Pick file (we use its folder)', subtype='FILE_PATH', default='')
     use_node_named_subfolder: BoolProperty(name='Put in subfolder named after node', default=True)
-    extra_subfolder: StringProperty(name='Extra subfolder (optional)', default='',
-        description='Tokens OK: {scene} {camera} {job} {node}')
+    extra_subfolder: StringProperty(
+        name='Extra subfolder (optional)',
+        default='',
+        description='Tokens OK: {scene} {camera} {job} {node}',
+    )
     ensure_dirs: BoolProperty(name='Create folders if missing', default=True)
     override_node_format: BoolProperty(name='Node format = Render format', default=True)
 
+
 class RQM_Job(PropertyGroup):
+    enabled: BoolProperty(
+        name='Enabled', default=True, description='Include this job when rendering the queue'
+    )
     name: StringProperty(name='Job Name', default='')
     scene_name: EnumProperty(name='Scene', items=scene_items)
     camera_name: EnumProperty(name='Camera', items=camera_items)
@@ -47,12 +77,24 @@ class RQM_Job(PropertyGroup):
     use_animation: BoolProperty(name='Render animation', default=False)
     frame_start: IntProperty(name='Start frame', default=1, min=0)
     frame_end: IntProperty(name='End frame', default=1, min=0)
-    preserve_frame_numbers: BoolProperty(name='Preserve frame numbers', default=True,
-        description='If enabled, renders use the original frame numbers (e.g. 20-30). If disabled, frames are remapped to start at 0 for this job.')
+    preserve_frame_numbers: BoolProperty(
+        name='Preserve frame numbers',
+        default=True,
+        description=(
+            'If enabled, renders use the original frame numbers (e.g. 20-30). '
+            'If disabled, frames are remapped to start at 0 for this job.'
+        ),
+    )
 
     # Single toggle to control using timeline markers for both start and end
-    link_timeline_markers: BoolProperty(name='Link timeline markers', default=False,
-        description='When enabled, use Start/End timeline markers (with offsets) and disable manual Start/End frame inputs')
+    link_timeline_markers: BoolProperty(
+        name='Link timeline markers',
+        default=False,
+        description=(
+            'When enabled, use Start/End timeline markers (with offsets) '
+            'and disable manual Start/End frame inputs'
+        ),
+    )
 
     link_marker: BoolProperty(name='Use start marker', default=False)
     marker_name: StringProperty(name='Start marker name', default='')
@@ -61,35 +103,75 @@ class RQM_Job(PropertyGroup):
     end_marker_name: StringProperty(name='End marker name', default='')
     end_marker_offset: IntProperty(name='End offset', default=-1)
 
-    zero_index_numbering: BoolProperty(name='(deprecated) 0-based numbering', default=True, options={'HIDDEN'})
+    zero_index_numbering: BoolProperty(
+        name='(deprecated) 0-based numbering', default=True, options={'HIDDEN'}
+    )
 
     file_format: EnumProperty(name='Render format', items=FILE_FORMAT_ITEMS, default='PNG')
     output_path: StringProperty(name='Render folder', subtype='DIR_PATH', default='//renders/')
-    file_basename: StringProperty(name='Render filename', default='render',
-        description="Prefix for main render files (sanitised). Example: 'beauty' -> beauty0001.png")
-    rebase_numbering: BoolProperty(name='Number files from 0', default=True,
-        description='For animations, rename output files so numbering starts at 0000 for this job, regardless of timeline frame indices')
+    file_basename: StringProperty(
+        name='Render filename',
+        default='render',
+        description="Prefix for main render files (sanitised). Example: 'beauty' -> beauty0001.png",
+    )
+    rebase_numbering: BoolProperty(
+        name='Number files from 0',
+        default=True,
+        description=(
+            'For animations, rename output files so numbering starts at 0000 '
+            'for this job, regardless of timeline frame indices'
+        ),
+    )
 
     use_comp_outputs: BoolProperty(name='Use Compositor outputs', default=False)
-    comp_outputs_non_blocking: BoolProperty(name='Don’t block render on compositor errors', default=True)
+    comp_outputs_non_blocking: BoolProperty(
+        name='Don’t block render on compositor errors', default=True
+    )
     comp_outputs: CollectionProperty(type=RQM_CompOutput)
     comp_outputs_index: IntProperty(default=0)
 
     # Stereoscopy / Multiview
-    use_stereoscopy: BoolProperty(name='Use Stereoscopy', default=False,
-        description='Enable multiview (stereoscopic) rendering for this job')
-    stereo_views_format: EnumProperty(name='Stereo Format', items=[
-        ('STEREO_3D', 'Stereo 3D', 'Left and Right views'),
-        ('MULTIVIEW', 'Multi-View', 'Use scene multi-view configuration')
-    ], default='STEREO_3D', description='How to configure view rendering for this job')
-    stereo_extra_tags: StringProperty(name='Extra view tags', default='',
-        description='Optional extra view identifiers (comma or space separated). Example: "ALT QA" -> produces _ALT and _QA tags')
-    stereo_keep_plain: BoolProperty(name='Keep plain fallback', default=True,
-        description='If off, plain (untagged) files are deleted once all view-tagged files for that frame exist')
+    use_stereoscopy: BoolProperty(
+        name='Use Stereoscopy',
+        default=False,
+        description='Enable multiview (stereoscopic) rendering for this job',
+    )
+    stereo_views_format: EnumProperty(
+        name='Stereo Format',
+        items=[
+            ('STEREO_3D', 'Stereo 3D', 'Left and Right views'),
+            ('MULTIVIEW', 'Multi-View', 'Use scene multi-view configuration'),
+        ],
+        default='STEREO_3D',
+        description='How to configure view rendering for this job',
+    )
+    stereo_extra_tags: StringProperty(
+        name='Extra view tags',
+        default='',
+        description=(
+            'Optional extra view identifiers (comma or space separated). '
+            'Example: "ALT QA" -> produces _ALT and _QA tags'
+        ),
+    )
+    stereo_keep_plain: BoolProperty(
+        name='Keep plain fallback',
+        default=True,
+        description=(
+            'If off, plain (untagged) files are deleted once all '
+            'view-tagged files for that frame exist'
+        ),
+    )
     stereo_tags: CollectionProperty(type=RQM_Tag)
     stereo_tags_index: IntProperty(default=0)
-    use_tag_collection: BoolProperty(name='Use tag list', default=False,
-        description='If enabled, only the tags in the list (checked) are used instead of the free-text field')
+    use_tag_collection: BoolProperty(
+        name='Use tag list',
+        default=False,
+        description=(
+            'If enabled, only the tags in the list (checked) are used '
+            'instead of the free-text field'
+        ),
+    )
+
 
 class RQM_State(PropertyGroup):
     queue: CollectionProperty(type=RQM_Job)

--- a/rqm/ui.py
+++ b/rqm/ui.py
@@ -1,28 +1,37 @@
 """UI Lists and Panels for the add-on (legacy layout parity)."""
+
 from __future__ import annotations
+
 import bpy  # type: ignore
-from bpy.types import UIList, Panel  # type: ignore
+from bpy.types import Panel, UIList  # type: ignore
+
 from .state import get_state
 
-__all__ = ['RQM_UL_Queue','RQM_UL_Outputs','RQM_UL_Tags','RQM_PT_Panel']
+__all__ = ['RQM_UL_Queue', 'RQM_UL_Outputs', 'RQM_UL_Tags', 'RQM_PT_Panel']
+
 
 class RQM_UL_Queue(UIList):
     bl_idname = 'RQM_UL_Queue'
+
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        if self.layout_type in {'DEFAULT','COMPACT'}:
+        if self.layout_type in {'DEFAULT', 'COMPACT'}:
             row = layout.row(align=True)
-            # Keep row clean: just name and context
-            row.prop(item, 'name', text='', emboss=False, icon='RENDER_RESULT')
+            row.prop(item, 'enabled', text='')
+            sub = row.row(align=True)
+            sub.enabled = item.enabled
+            sub.prop(item, 'name', text='', emboss=False, icon='RENDER_RESULT')
             cam_part = item.camera_name or '<no cam>'
-            row.label(text=f"{item.scene_name}:{cam_part}")
+            sub.label(text=f"{item.scene_name}:{cam_part}")
         else:
             layout.alignment = 'CENTER'
             layout.label(text='', icon='RENDER_RESULT')
 
+
 class RQM_UL_Outputs(UIList):
     bl_idname = 'RQM_UL_Outputs'
+
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        if self.layout_type in {'DEFAULT','COMPACT'}:
+        if self.layout_type in {'DEFAULT', 'COMPACT'}:
             row = layout.row(align=True)
             row.prop(item, 'enabled', text='')
             # show as shorter label + editable text button
@@ -32,15 +41,18 @@ class RQM_UL_Outputs(UIList):
             layout.alignment = 'CENTER'
             layout.label(text='', icon='NODE_COMPOSITING')
 
+
 class RQM_UL_Tags(UIList):
     bl_idname = 'RQM_UL_Tags'
+
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        if self.layout_type in {'DEFAULT','COMPACT'}:
+        if self.layout_type in {'DEFAULT', 'COMPACT'}:
             row = layout.row(align=True)
             row.prop(item, 'enabled', text='')
             row.prop(item, 'name', text='', emboss=True, icon='VIEW_CAMERA')
         else:
             layout.label(text=item.name)
+
 
 class RQM_PT_Panel(Panel):
     bl_label = 'Render Queue Manager'
@@ -67,7 +79,6 @@ class RQM_PT_Panel(Panel):
         row_list.template_list('RQM_UL_Queue', '', st, 'queue', st, 'active_index', rows=6)
         side = row_list.column(align=True)
         if 0 <= st.active_index < len(st.queue):
-            job_side = st.queue[st.active_index]
             dup = side.operator('rqm.duplicate_job', text='', icon='DUPLICATE')
             dup.index = st.active_index
             rem = side.operator('rqm.remove_job', text='', icon='X')
@@ -85,6 +96,7 @@ class RQM_PT_Panel(Panel):
                 top_row.use_property_decorate = False
             except Exception:
                 pass
+            top_row.prop(job, 'enabled', text='')
             top_row.prop(job, 'name', text='Name')
 
             row = box.row()
@@ -97,35 +109,48 @@ class RQM_PT_Panel(Panel):
             col = box.column(align=True)
             col.label(text='Resolution')
             rr = col.row(align=True)
-            rr.prop(job, 'res_x'); rr.prop(job, 'res_y'); rr.prop(job, 'percent')
+            rr.prop(job, 'res_x')
+            rr.prop(job, 'res_y')
+            rr.prop(job, 'percent')
 
-            col.separator(); col.prop(job, 'use_animation')
+            col.separator()
+            col.prop(job, 'use_animation')
             if job.use_animation:
                 fr = col.row(align=True)
                 fr.enabled = not getattr(job, 'link_timeline_markers', False)
-                fr.prop(job, 'frame_start'); fr.prop(job, 'frame_end')
-                col.separator(); col.label(text='Timeline markers', icon='MARKER_HLT')
+                fr.prop(job, 'frame_start')
+                fr.prop(job, 'frame_end')
+                col.separator()
+                col.label(text='Timeline markers', icon='MARKER_HLT')
                 col.prop(job, 'link_timeline_markers', text='Link timeline markers')
                 if getattr(job, 'link_timeline_markers', False):
                     r = col.row(align=True)
                     if scn_for_job:
-                        r.prop_search(job, 'marker_name', scn_for_job, 'timeline_markers', text='Start')
+                        r.prop_search(
+                            job, 'marker_name', scn_for_job, 'timeline_markers', text='Start'
+                        )
                     else:
                         r.prop(job, 'marker_name', text='Start')
                     r.prop(job, 'marker_offset')
                     r2 = col.row(align=True)
                     if scn_for_job:
-                        r2.prop_search(job, 'end_marker_name', scn_for_job, 'timeline_markers', text='End')
+                        r2.prop_search(
+                            job, 'end_marker_name', scn_for_job, 'timeline_markers', text='End'
+                        )
                     else:
                         r2.prop(job, 'end_marker_name', text='End')
                     r2.prop(job, 'end_marker_offset')
 
-            col.separator(); col.label(text='Standard Output', icon='FILE_FOLDER')
-            col.prop(job, 'file_format'); col.prop(job, 'output_path'); col.prop(job, 'file_basename')
+            col.separator()
+            col.label(text='Standard Output', icon='FILE_FOLDER')
+            col.prop(job, 'file_format')
+            col.prop(job, 'output_path')
+            col.prop(job, 'file_basename')
             if job.use_animation and hasattr(job, 'rebase_numbering'):
                 col.prop(job, 'rebase_numbering')
 
-            col.separator(); col.label(text='Stereoscopy', icon='CAMERA_STEREO')
+            col.separator()
+            col.label(text='Stereoscopy', icon='CAMERA_STEREO')
             col.prop(job, 'use_stereoscopy')
             if getattr(job, 'use_stereoscopy', False):
                 if hasattr(job, 'stereo_views_format'):
@@ -137,31 +162,45 @@ class RQM_PT_Panel(Panel):
                     tag_row.prop(job, 'use_tag_collection', text='Use Tag List')
                 if getattr(job, 'use_tag_collection', False):
                     tag_box = col.box()
-                    tag_box.template_list('RQM_UL_Tags', '', job, 'stereo_tags', job, 'stereo_tags_index', rows=3)
+                    tag_box.template_list(
+                        'RQM_UL_Tags', '', job, 'stereo_tags', job, 'stereo_tags_index', rows=3
+                    )
 
-            col.separator(); col.label(text='Compositor Outputs', icon='NODE_COMPOSITING')
+            col.separator()
+            col.label(text='Compositor Outputs', icon='NODE_COMPOSITING')
             col.prop(job, 'use_comp_outputs')
             if job.use_comp_outputs:
                 col.prop(job, 'comp_outputs_non_blocking')
                 row = col.row()
-                row.template_list('RQM_UL_Outputs', '', job, 'comp_outputs', job, 'comp_outputs_index', rows=3)
+                row.template_list(
+                    'RQM_UL_Outputs', '', job, 'comp_outputs', job, 'comp_outputs_index', rows=3
+                )
                 col2 = row.column(align=True)
                 col2.operator('rqm.output_add', icon='ADD', text='')
                 col2.operator('rqm.output_remove', icon='REMOVE', text='')
                 col2.separator()
-                up = col2.operator('rqm.output_move', icon='TRIA_UP', text=''); up.direction='UP'
-                dn = col2.operator('rqm.output_move', icon='TRIA_DOWN', text=''); dn.direction='DOWN'
+                up = col2.operator('rqm.output_move', icon='TRIA_UP', text='')
+                up.direction = 'UP'
+                dn = col2.operator('rqm.output_move', icon='TRIA_DOWN', text='')
+                dn.direction = 'DOWN'
                 if 0 <= job.comp_outputs_index < len(job.comp_outputs):
                     out = job.comp_outputs[job.comp_outputs_index]
                     sub = col.box()
                     sub.prop(out, 'enabled')
                     if scn_for_job and scn_for_job.node_tree:
-                        sub.prop_search(out, 'node_name', scn_for_job.node_tree, 'nodes', text='File Output Node')
+                        sub.prop_search(
+                            out,
+                            'node_name',
+                            scn_for_job.node_tree,
+                            'nodes',
+                            text='File Output Node',
+                        )
                     else:
                         sub.prop(out, 'node_name', text='File Output Node')
                     sub.prop(out, 'create_if_missing')
                     sub.prop(out, 'override_node_format')
-                    sub.separator(); sub.label(text='Save location', icon='FILE_FOLDER')
+                    sub.separator()
+                    sub.label(text='Save location', icon='FILE_FOLDER')
                     sub.prop(out, 'base_source', text='Base')
                     if out.base_source == 'FROM_FILE':
                         sub.prop(out, 'base_file')


### PR DESCRIPTION
## Summary
- allow jobs in the render queue to be toggled on/off
- show an enable checkbox in job lists and detail view
- skip disabled jobs during queue execution

## Testing
- `python -m black rqm/properties.py rqm/ui.py rqm/operators_queue.py`
- `python -m ruff check rqm/properties.py rqm/ui.py rqm/operators_queue.py`

